### PR TITLE
fix: Fixed a typo in the "@config/*" path in tsconfig.json

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -26,7 +26,7 @@
         "src/*"
       ],
       "@config/*": [
-        "src/configs/*"
+        "src/config/*"
       ],
       "@lib": [
         "src/lib/*"


### PR DESCRIPTION
修正了tsconfig.json中"@config/*"路径的笔误，将"configs"更改为"config"，确保模块导入路径正确解析。